### PR TITLE
Updated location. Fixed interpolation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@
 
 ## What's new in v1.1?
 - multiple WRF output files are allowed
-- move from wrf-python to salem to modify RAM usage and computation time 
+- move from wrf-python to salem to modify RAM usage and computation time
 - use xarray instead of netCDF4 package to modify RAM usage and computation time
-- apply multiprocessing to improve computation time 
+- apply multiprocessing to improve computation time
 - users now only need to edit namelist instead of editing the script  
-- add surface variables (e.g. U10, V10, T2, and Q2) for surface NaN solver 
-- read WRF projection info when locate PALM domain 
+- add surface variables (e.g. U10, V10, T2, and Q2) for surface NaN solver
+- read WRF projection info when locate PALM domain
 - allow users to specify the projection of PALM simulation
-- geostrophic winds are estimated using geopotential height instead of pressure 
+- geostrophic winds are estimated using geopotential height instead of pressure
 
 ## Instrustions
 **How to use WRF4PALM v1.1**
@@ -27,7 +27,7 @@
 4. [Run WRF4PALM](https://github.com/dongqi-DQ/WRF4PALM/tree/v1.1#one-line-command)
 
 
-### namelist 
+### namelist
 In v1.1, users don't have to edit the main script, and only need to edit the namelist file to provide their input (for examples please see `namelist.wrf4palm`).
 
 There are 5 sections in the namelist:
@@ -46,7 +46,7 @@ max_pool = 4,                # specify the maximum number of CPUs to use
 ```
 
 #### domain
-In the `domain` section, users need to provide PALM domain configuration (dx, dy, dz, nx, ny, nz, and z_origin), the latitude and longitude at PALM domain centre, and the projection of PALM domain. The projection of PALM domain and centre lat/lon are used to locate PALM domain in the WRF domain. The projection of PALM domain should be identical to the projection of PALM static driver, if the user has one. If users do not have the projection information, they can leave the field empty as `palm_proj = "",` such that WRF4PALM v1.1 will use the projetion of WRF directly. 
+In the `domain` section, users need to provide PALM domain configuration (dx, dy, dz, nx, ny, nz, and z_origin), the latitude and longitude at PALM domain centre, and the projection of PALM domain. The projection of PALM domain and centre lat/lon are used to locate PALM domain in the WRF domain. The projection of PALM domain should be identical to the projection of PALM static driver, if the user has one. If users do not have the projection information, they can leave the field empty as `palm_proj = "",` such that WRF4PALM v1.1 will use the projetion of WRF directly.
 
 ```
 [domain]
@@ -121,7 +121,7 @@ msoil = 0.3,         # dummy value in case soil moisture from WRF output is 0.0
 ### One line command
 Once the namelist is ready, users can run WRF4PALM using the one line command:
 ```
-python run_config_wrf4palm.py [your namelist] 
+python run_config_wrf4palm.py [your namelist]
 ```
 
 **Execution example**
@@ -184,7 +184,7 @@ In order for users to quickly check the quality of the dynamic driver generated 
 Three plot types are provided:
 1. **zcross**: vertical cross sections of west/east/south/north boundaries for the user specified variable and timestamp
 ```
-python quick_compare.py [your namelist] zcross [variable name] 
+python3 quick_compare.py [your namelist] zcross [variable name]
 ```
 then the script will ask for the timestamp:
 ```
@@ -194,7 +194,7 @@ Once the timestamp is given, the script will return a comparison plot.
 
 2. **pr**: vertical profiless of west/east/south/north boundaries for the user specified variable and timestamp
 ```
-python quick_compare.py [your namelist] pr [variable name] 
+python3 quick_compare.py [your namelist] pr [variable name]
 ```
 then the script will ask for the timestamp:
 ```
@@ -205,7 +205,7 @@ Note that the vertical profiles are horizontally averaged and hence the comparis
 
 2. **ts**: time series of west/east/south/north boundaries for the user specified variable and altitude
 ```
-python quick_compare.py [your namelist] ts [variable name] 
+python3 quick_compare.py [your namelist] ts [variable name]
 ```
 then the script will ask for the altitude:
 ```
@@ -216,19 +216,19 @@ Note that the time series are horizontally averaged and hence the comparison onl
 
 ## Remark
 - [`Surface_NaN_Solver.pdf`](https://github.com/dongqi-DQ/WRF4PALM/blob/v1.1/Surface_NaN_Solver.pdf) provides a short documentation explaining how the surface nans are resolved.
-- The WRF4PALM v1.1 python environemnt is available in [`wrf4palm_env.yml`](https://github.com/dongqi-DQ/WRF4PALM/blob/v1.1/wrf4palm_env.yml). 
+- The WRF4PALM v1.1 python environemnt is available in [`wrf4palm_env.yml`](https://github.com/dongqi-DQ/WRF4PALM/blob/v1.1/wrf4palm_env.yml).
 
 # Note  
-- We noticed that PALM uses a water temperature of 283 K as default, which may lead to a stable layer over water bodies (if there are any in the PALM simulation domain). We recommend users to modify the water temperatuer using the static driver. 
+- We noticed that PALM uses a water temperature of 283 K as default, which may lead to a stable layer over water bodies (if there are any in the PALM simulation domain). We recommend users to modify the water temperatuer using the static driver.
 - We may release a static driver generator using global data set from Google earth engine and SST from ERA5 (date TBC).
 - Geostrophic winds are only an estimation while the accuracy of the estimation still needs further discussion and investigation. This problem is the same in INIFOR.
 - We encourage WRF4PALM users to use the GitHub **Issue** system if they encountered any issues or problems using WRF4PALM such that communications and trouble shooting will be easier.
 
 --------------------------------------------------------------------------------------------
-### End of README 
+### End of README
 --------------------------------------------------------------------------------------------
 
-Development of WRF4PALM is based on WRF2PALM (https://github.com/ricardo88faria/WRF2PALM). 
+Development of WRF4PALM is based on WRF2PALM (https://github.com/ricardo88faria/WRF2PALM).
 
 A full documentation is still under construction, if you have any queries please contact the author or open a new issue.
 
@@ -237,6 +237,4 @@ A full documentation is still under construction, if you have any queries please
 
 **How to cite**
 
-Lin, D., Khan, B., Katurji, M., Bird, L., Faria, R., and Revell, L. E.: WRF4PALM v1.0: a mesoscale dynamical driver for the microscale PALM model system 6.0, Geosci. Model Dev., 14, 2503–2524, https://doi.org/10.5194/gmd-14-2503-2021, 2021. 
-
-
+Lin, D., Khan, B., Katurji, M., Bird, L., Faria, R., and Revell, L. E.: WRF4PALM v1.0: a mesoscale dynamical driver for the microscale PALM model system 6.0, Geosci. Model Dev., 14, 2503–2524, https://doi.org/10.5194/gmd-14-2503-2021, 2021.

--- a/dynamic_util/loc_dom.py
+++ b/dynamic_util/loc_dom.py
@@ -53,7 +53,7 @@ def domain_location(palm_proj, wgs_proj, centlat, centlon, dx, dy, nx, ny):
         west, east   = centx-nx*dx/2, centx+nx*dx/2
         north, south = centy+ny*dy/2, centy-ny*dy/2
 
-    return west, east, south, north
+    return west, east, south, north, centx, centy
 
 
 def generate_cfg(case_name, dx, dy, dz, nx, ny, nz, west, east, south, north, centlat, centlon, z_origin):

--- a/dynamic_util/nearest.py
+++ b/dynamic_util/nearest.py
@@ -8,23 +8,43 @@
 # @ WRF2PALM author: Ricardo Faria (https://github.com/ricardo88faria/WRF2PALM)
 # @ WRF4PALM contact: Dongqi Lin (dongqi.lin@pg.canterbury.ac.nz)
 #--------------------------------------------------------------------------------#
+import numpy as np
+
+def framing_2d_cartesian(lons_wrf,lats_wrf, west,east,south,north):
+    nearest_wix = np.argmin(np.abs(lons_wrf[0]-west))
+    if lons_wrf[0][nearest_wix]>west:
+        nearest_wix-=1
+    nearest_eix = np.argmin(np.abs(lons_wrf[0]-east))
+    if lons_wrf[0][nearest_eix]<east:
+        nearest_eix+=1
+
+    lats_wrf_y = np.array([x[0] for x in lats_wrf])
+
+    nearest_six = np.argmin(np.abs(lats_wrf_y-south))
+    if lats_wrf_y[nearest_six]>south:
+        nearest_six-=1
+    nearest_nix = np.argmin(np.abs(lats_wrf_y-north))
+    if lats_wrf_y[nearest_nix]<north:
+        nearest_nix+=1
+
+    return nearest_wix, nearest_eix, nearest_six, nearest_nix
+
+
 def nearest_2d(array, number):
     
     '''
     
     find nearest index value and index in a 2D array.
     
-    nearest(array, number) 
+    nearest(array, number)
     
     return(nearest_number, nearest_index)
     
     '''
-    
-    import numpy as np
-    
-    index = np.where(np.abs(array-number) == np.nanmin(np.abs(array-number)))
+      
+    index = np.where(np.abs(array-number) == np.nanmin(np.abs(array-number)))#index is single pair of naturals, if only array isn't anywhere cartesian.
     idx, idy = index[0], index[1]
-    nearest_number = array[idx, idy]
+    nearest_number = array[idx, idy]#1D array of length 1 or Nx of Ny.
     nearest_index = [idx[0], idy[0]]
     
     return(nearest_number[0], nearest_index)
@@ -35,13 +55,11 @@ def nearest_1d(array, number):
     
     find nearest index value and index in array.
     
-    nearest(array, number) 
+    nearest(array, number)
     
     return(nearest_number, nearest_index)
     
     '''
-    
-    import numpy as np
     
     nearest_index = np.where(np.abs(array-number) == np.nanmin(np.abs(array-number)))
     nearest_index = int(nearest_index[0][0])

--- a/dynamic_util/surface_nan_solver.py
+++ b/dynamic_util/surface_nan_solver.py
@@ -36,7 +36,7 @@ def surface_nan_s(data,z,s2):
     return(data)
 def surface_nan_w(data):
     '''
-    do nothing for vertical wind 
+    do nothing for vertical wind
     '''
     nan_idx = np.argwhere(np.isnan(data))
     if nan_idx.size > 0 :

--- a/namelist.wrf4palm
+++ b/namelist.wrf4palm
@@ -1,5 +1,5 @@
 [case]
-case_name = "wrf4palm_test", 
+case_name = "wrf4palm_test",
 max_pool = 4,
 
 [domain]

--- a/quick_compare.py
+++ b/quick_compare.py
@@ -255,7 +255,8 @@ ds_drop = ds_wrf.where(mask_sn & mask_we, drop=True)
 #-------------------------------------------------------------------------------
 # Read dynamic driver
 #-------------------------------------------------------------------------------
-ds_dynamic = xr.open_dataset(f'dynamic_files/{case_name}_dynamic_{start_year}_{start_month}_{start_day}_{start_hour}')
+dynstr = f'dynamic_files/{case_name}_dynamic_{start_year}_{start_month}_{start_day}_{start_hour}'
+ds_dynamic = xr.open_dataset(dynstr)
 #-------------------------------------------------------------------------------
 # Plotting functions
 #-------------------------------------------------------------------------------

--- a/quick_compare.py
+++ b/quick_compare.py
@@ -33,7 +33,7 @@ from datetime import datetime, timedelta
 from tqdm import tqdm
 from functools import partial
 from multiprocess import Pool
-from dynamic_util.nearest import nearest_2d, nearest_1d
+from dynamic_util.nearest import framing_2d_cartesian, nearest_1d
 from dynamic_util.loc_dom import calc_stretch, domain_location, generate_cfg
 from dynamic_util.process_wrf import zinterp, multi_zinterp, process_top
 from dynamic_util.geostrophic import calc_geostrophic_wind
@@ -224,7 +224,7 @@ else:
 trans_wrf2palm = Transformer.from_proj(wrf_proj, palm_proj)
 lons_wrf,lats_wrf = trans_wrf2palm.transform(xx_wrf, yy_wrf)
 
-west, east, south, north = domain_location(palm_proj, wgs_proj, centlat, centlon,
+west, east, south, north, centx, centy = domain_location(palm_proj, wgs_proj, centlat, centlon,
                                            dx, dy, nx, ny)
 
 ## write a cfg file for future reference
@@ -232,8 +232,7 @@ generate_cfg(case_name, dx, dy, dz, nx, ny, nz,
              west, east, south, north, centlat, centlon,z_origin)
 
 # find indices of closest values
-south_idx, north_idx = nearest_2d(lats_wrf, south)[1][0], nearest_2d(lats_wrf, north)[1][0]
-west_idx, east_idx = nearest_2d(lons_wrf, west)[1][1], nearest_2d(lons_wrf, east)[1][1]
+west_idx,east_idx,south_idx,north_idx = framing_2d_cartesian(lons_wrf,lats_wrf, west,east,south,north)
 # in case negative longitudes are used
 # these two lines may be redundant need further tests 27 Oct 2021
 if east_idx-west_idx<0:

--- a/run_config_wrf4palm.py
+++ b/run_config_wrf4palm.py
@@ -341,11 +341,11 @@ print("ds_we1")
 ds_we = ds_interp.isel(west_east=[0,-1])
 ds_sn = ds_interp.isel(south_north=[0,-1])
 
-print("ds_we_unstag1")
+print("ds_we_ustag1")
 ds_we_ustag = ds_interp_u.isel(west_east=[0,-1])
 ds_we_vstag = ds_interp_v.isel(west_east=[0,-1])
 
-print("ds_sn_unstag1")
+print("ds_sn_ustag1")
 ds_sn_ustag = ds_interp_u.isel(south_north=[0,-1])
 ds_sn_vstag = ds_interp_v.isel(south_north=[0,-1])
 
@@ -369,10 +369,12 @@ ds_sn = ds_sn.load()
 
 print("load ds_we_ustag")
 ds_we_ustag = ds_we_ustag.load()
+print("load ds_sn_ustag")
 ds_sn_ustag = ds_sn_ustag.load()
 
 print("load ds_we_vstag")
 ds_we_vstag = ds_we_vstag.load()
+print("load ds_sn_vstag")
 ds_sn_vstag = ds_sn_vstag.load()
 
 print("ds_palm_we")
@@ -445,8 +447,11 @@ for var in ds_interp.data_vars:
     if var not in ["V", "Z"]:
         ds_interp_v = ds_interp_v.drop(var)
 print("Processing top boundary conditions...load")
+print("Processing top boundary conditions...load.ds_interp")
 ds_interp = ds_interp.load()
+print("Processing top boundary conditions...load.ds_interp_u")
 ds_interp_u = ds_interp_u.load()
+print("Processing top boundary conditions...load.ds_interp_v")
 ds_interp_v = ds_interp_v.load()
 
 
@@ -479,6 +484,7 @@ lat_geostr = ds_drop.lat[:,0]
 dx_wrf = ds_drop.DX
 dy_wrf = ds_drop.DY
 gph = ds_drop.gph
+print("Geostrophic wind estimation...gph.load()")
 gph = gph.load()
 ds_geostr = xr.Dataset()
 ds_geostr = ds_geostr.assign_coords({"time":ds_drop.time.data,

--- a/run_config_wrf4palm.py
+++ b/run_config_wrf4palm.py
@@ -52,7 +52,7 @@ settings_cfg = configparser.ConfigParser(inline_comment_prefixes='#')
 config = configparser.RawConfigParser()
 config.read(sys.argv[1])#"namelist.test")
 case_name =  ast.literal_eval(config.get("case", "case_name"))[0]
-max_pool =  ast.literal_eval(config.get("case", "max_pool"))[0]
+max_pool  =  ast.literal_eval(config.get("case", "max_pool" ))[0]
 
 palm_proj_code = ast.literal_eval(config.get("domain", "palm_proj"))[0]
 centlat = ast.literal_eval(config.get("domain", "centlat"))[0]
@@ -367,7 +367,7 @@ ds_we = ds_we.load()
 print("load ds_sn")
 ds_sn = ds_sn.load()
 
-print("load ds_we_unstag")
+print("load ds_we_ustag")
 ds_we_ustag = ds_we_ustag.load()
 ds_sn_ustag = ds_sn_ustag.load()
 
@@ -436,7 +436,7 @@ v_top = np.zeros((len(all_ts), len(yv), len(x)))
 w_top = np.zeros((len(all_ts), len(y), len(x)))
 qv_top = np.zeros((len(all_ts), len(y), len(x)))
 pt_top = np.zeros((len(all_ts), len(y), len(x)))
-
+print("Processing top boundary conditions...loop")
 for var in ds_interp.data_vars:
     if var not in varbc_list:
         ds_interp = ds_interp.drop(var)
@@ -444,7 +444,7 @@ for var in ds_interp.data_vars:
         ds_interp_u = ds_interp_u.drop(var)
     if var not in ["V", "Z"]:
         ds_interp_v = ds_interp_v.drop(var)
-
+print("Processing top boundary conditions...load")
 ds_interp = ds_interp.load()
 ds_interp_u = ds_interp_u.load()
 ds_interp_v = ds_interp_v.load()
@@ -455,7 +455,7 @@ top_dict = {"U": (ds_interp_u, u_top, z),
             "pt": (ds_interp, pt_top, z),
             "QVAPOR": (ds_interp, qv_top, z),
             "W": (ds_interp, w_top, zw)}
-
+print("Processing top boundary conditions...pool")
 with Pool(max_pool) as p:
         pool_outputs = list(
             tqdm(

--- a/wrf_output/wrfout_d04_2020-12-25_12-00-00
+++ b/wrf_output/wrfout_d04_2020-12-25_12-00-00
@@ -1,1 +1,0 @@
-/data/wrf4palm_playground/wrfout_d04_2020-12-25_12-00-00

--- a/wrf_output/wrfout_d04_2020-12-26_12-00-00
+++ b/wrf_output/wrfout_d04_2020-12-26_12-00-00
@@ -1,1 +1,0 @@
-/data/wrf4palm_playground/wrfout_d04_2020-12-26_12-00-00


### PR DESCRIPTION
**Dynamic file output had not yet been tested with PALM.**
"zcross U" shows WRF field complies with dynamic file field. [palm vs wrf](https://yadi.sk/i/cTxwFYIHsmH4hw)
New:
PALM domain's lateral coordinates do not snap to WRF grid nodes. Could be an overprecision.
Nearest WRF nodes to PALM domain's corners frame a space. If PALM domain's parts remain anywhere beyond the framing, new WRF nodes are included for complete framing of PALM domain. Solves #7 and #11.
Some lines in _quick_compare.py_ can be executed with _python3_ only. _Readme.md_ is updated.