### PR TITLE
fixed vertical stretching, tested, PALM accepts it

### DIFF
--- a/dynamic_util/loc_dom.py
+++ b/dynamic_util/loc_dom.py
@@ -65,7 +65,7 @@ def generate_cfg(case_name, dx, dy, dz, nx, ny, nz, west, east, south, north, ce
 
 
 
-def calc_stretch(z, dz, zw, dz_stretch_level,dz_stretch_factor, dz_stretch_level, dz_max):
+def calc_stretch(z, dz, zw, dz_stretch_factor, dz_stretch_level, dz_max):
     '''
     vertically streched levels
     '''

--- a/run_config_wrf4palm.py
+++ b/run_config_wrf4palm.py
@@ -76,7 +76,7 @@ z_origin = ast.literal_eval(config.get("domain", "z_origin"))[0]
 
 y = np.arange(dy/2,dy*ny+dy/2,dy)
 x = np.arange(dx/2,dx*nx+dx/2,dx)
-z = np.arange(dz/2, dz*nz, dz) + z_origin
+z = np.arange(dz/2, dz*nz, dz)
 xu = x + np.gradient(x)/2
 xu = xu[:-1]
 yv = y + np.gradient(y)/2
@@ -95,7 +95,10 @@ dz_stretch_level = ast.literal_eval(config.get("stretch", "dz_stretch_level"))[0
 dz_max = ast.literal_eval(config.get("stretch", "dz_max"))[0]
 
 if dz_stretch_factor>1.0:
-    z, zw = calc_stretch(z, dz, zw, dz_stretch_level,dz_stretch_factor, dz_stretch_level, dz_max)
+    z, zw = calc_stretch(z, dz, zw, dz_stretch_factor, dz_stretch_level, dz_max)
+
+z += z_origin
+zw += z_origin
 
 dz_soil = np.array(ast.literal_eval(config.get("soil", "dz_soil")))
 msoil_val = np.array(ast.literal_eval(config.get("soil", "msoil")))[0]


### PR DESCRIPTION
Hi Dongqi,

I hope you are well.

I found another issue with the vertical stretching. Adding the value `z_origin` before calling `calc_stretch` leads to wrong vertical z- and zw-levels, e.g. -31.33452. My solution is to first call `calc_stretch`, and then add `z_origin` later.

Also, in the function call `calc_stretch`, the variable `dz_stretch_level` is listed twice.

This Pull request has all relevant changes. I tested this code and it runs fine. I compared the vertical levels to PALM results using the same stretching and they are the same. Also, PALM accepts the vertical levels and runs fine.

Best Regards,
Julian